### PR TITLE
Implement makemodel and serial attribute matching

### DIFF
--- a/site/xsd-doc/hosts.html
+++ b/site/xsd-doc/hosts.html
@@ -960,6 +960,12 @@ setState('element_wpkg_scbox', false);
 <span style="margin-left: 0.5em"> os="<span class="type">
 <a href="wpkg.html#ns_xsd" title="Find out namespace of 'xsd' prefix">xsd</a>:string</span> <span class="occurs">[0..1]</span> <a href="javascript:void(0)" title="View Documentation" class="documentation" onclick="docArray = new Array('Regular expression which matches host operating system. e.g. \'microsoft windows 7 professional\' Host OS description string will have the following format: \'[OS-caption], [OS-description],[CSD-version], [OS-version]\''); viewDocumentation('Attribute', 'os', docArray);">?</a>"</span>
 <br/>
+<span style="margin-left: 0.5em"> makemodel="<span class="type">
+<a href="wpkg.html#ns_xsd" title="Find out namespace of 'xsd' prefix">xsd</a>:string</span> <span class="occurs">[0..1]</span> <a href="javascript:void(0)" title="View Documentation" class="documentation" onclick="docArray = new Array('Regular expression which matches host make and model. e.g. \'hewlett-packard, probook 4550b\' Host makemodel description string will have the following format: \'[CS-Manufacturer], [CS-Model]\''); viewDocumentation('Attribute', 'makemodel', docArray);">?</a>"</span>
+<br/>
+<span style="margin-left: 0.5em"> serial="<span class="type">
+<a href="wpkg.html#ns_xsd" title="Find out namespace of 'xsd' prefix">xsd</a>:string</span> <span class="occurs">[0..1]</span> <a href="javascript:void(0)" title="View Documentation" class="documentation" onclick="docArray = new Array('Regular expression which matches host serial number. Host serial description string will have the following format: \'[BIOS-SerialNumber]\''); viewDocumentation('Attribute', 'serial', docArray);">?</a>"</span>
+<br/>
 <span style="margin-left: 0.5em"> ipaddresses="<span class="type">
 <a href="wpkg.html#ns_xsd" title="Find out namespace of 'xsd' prefix">xsd</a>:string</span> <span class="occurs">[0..1]</span> <a href="javascript:void(0)" title="View Documentation" class="documentation" onclick="docArray = new Array('Regular expression matching machine IP address. Any IP address of the host (if it has multiple) will have to match this expression. e.g. ^192\.168\.1\..*'); viewDocumentation('Attribute', 'ipaddresses', docArray);">?</a>"</span>
 <br/>
@@ -1095,6 +1101,12 @@ setState('type_host_scbox', false);
 <br/>
 <span style="margin-left: 0.5em"> os="<span class="type">
 <a href="wpkg.html#ns_xsd" title="Find out namespace of 'xsd' prefix">xsd</a>:string</span> <span class="occurs">[0..1]</span> <a href="javascript:void(0)" title="View Documentation" class="documentation" onclick="docArray = new Array('Regular expression which matches host operating system. e.g. \'microsoft windows 7 professional\' Host OS description string will have the following format: \'[OS-caption], [OS-description],[CSD-version], [OS-version]\''); viewDocumentation('Attribute', 'os', docArray);">?</a>"</span>
+<br/>
+<span style="margin-left: 0.5em"> makemodel="<span class="type">
+<a href="wpkg.html#ns_xsd" title="Find out namespace of 'xsd' prefix">xsd</a>:string</span> <span class="occurs">[0..1]</span> <a href="javascript:void(0)" title="View Documentation" class="documentation" onclick="docArray = new Array('Regular expression which matches host make and model. e.g. \'hewlett-packard, probook 4550b\' Host makemodel description string will have the following format: \'[CS-Manufacturer], [CS-Model]\''); viewDocumentation('Attribute', 'makemodel', docArray);">?</a>"</span>
+<br/>
+<span style="margin-left: 0.5em"> serial="<span class="type">
+<a href="wpkg.html#ns_xsd" title="Find out namespace of 'xsd' prefix">xsd</a>:string</span> <span class="occurs">[0..1]</span> <a href="javascript:void(0)" title="View Documentation" class="documentation" onclick="docArray = new Array('Regular expression which matches host serial number. Host serial description string will have the following format: \'[BIOS-SerialNumber]\''); viewDocumentation('Attribute', 'serial', docArray);">?</a>"</span>
 <br/>
 <span style="margin-left: 0.5em"> ipaddresses="<span class="type">
 <a href="wpkg.html#ns_xsd" title="Find out namespace of 'xsd' prefix">xsd</a>:string</span> <span class="occurs">[0..1]</span> <a href="javascript:void(0)" title="View Documentation" class="documentation" onclick="docArray = new Array('Regular expression matching machine IP address. Any IP address of the host (if it has multiple) will have to match this expression. e.g. ^192\.168\.1\..*'); viewDocumentation('Attribute', 'ipaddresses', docArray);">?</a>"</span>

--- a/site/xsd-doc/packages.html
+++ b/site/xsd-doc/packages.html
@@ -1019,6 +1019,12 @@ setState('element_packages_scbox', false);
 <span style="margin-left: 0.5em"> os="<span class="type">
 <a href="wpkg.html#ns_xsd" title="Find out namespace of 'xsd' prefix">xsd</a>:string</span> <span class="occurs">[0..1]</span> <a href="javascript:void(0)" title="View Documentation" class="documentation" onclick="docArray = new Array('Regular expression which matches host operating system. e.g. \'microsoft windows 7 professional\' Host OS description string will have the following format: \'[OS-caption], [OS-description],[CSD-version], [OS-version]\''); viewDocumentation('Attribute', 'os', docArray);">?</a>"</span>
 <br/>
+<span style="margin-left: 0.5em"> makemodel="<span class="type">
+<a href="wpkg.html#ns_xsd" title="Find out namespace of 'xsd' prefix">xsd</a>:string</span> <span class="occurs">[0..1]</span> <a href="javascript:void(0)" title="View Documentation" class="documentation" onclick="docArray = new Array('Regular expression which matches host make and model. e.g. \'hewlett-packard, probook 4550b\' Host makemodel description string will have the following format: \'[CS-Manufacturer], [CS-Model]\''); viewDocumentation('Attribute', 'makemodel', docArray);">?</a>"</span>
+<br/>
+<span style="margin-left: 0.5em"> serial="<span class="type">
+<a href="wpkg.html#ns_xsd" title="Find out namespace of 'xsd' prefix">xsd</a>:string</span> <span class="occurs">[0..1]</span> <a href="javascript:void(0)" title="View Documentation" class="documentation" onclick="docArray = new Array('Regular expression which matches host serial number. Host serial description string will have the following format: \'[BIOS-SerialNumber]\''); viewDocumentation('Attribute', 'serial', docArray);">?</a>"</span>
+<br/>
 <span style="margin-left: 0.5em"> ipaddresses="<span class="type">
 <a href="wpkg.html#ns_xsd" title="Find out namespace of 'xsd' prefix">xsd</a>:string</span> <span class="occurs">[0..1]</span> <a href="javascript:void(0)" title="View Documentation" class="documentation" onclick="docArray = new Array('Regular expression matching machine IP address. Any IP address of the host (if it has multiple) will have to match this expression. e.g. ^192\.168\.1\..*'); viewDocumentation('Attribute', 'ipaddresses', docArray);">?</a>"</span>
 <br/>
@@ -1187,6 +1193,12 @@ setState('type_command_scbox', false);
 <span style="margin-left: 0.5em" class="inherited"> os="<span class="type">
 <a href="wpkg.html#ns_xsd" title="Find out namespace of 'xsd' prefix">xsd</a>:string</span> <span class="occurs">[0..1]</span> <a href="javascript:void(0)" title="View Documentation" class="documentation" onclick="docArray = new Array('Regular expression which matches host operating system. e.g. \'microsoft windows 7 professional\' Host OS description string will have the following format: \'[OS-caption], [OS-description],[CSD-version], [OS-version]\''); viewDocumentation('Attribute', 'os', docArray);">?</a>"</span>
 <br/>
+<span style="margin-left: 0.5em" class="inherited"> makemodel="<span class="type">
+<a href="wpkg.html#ns_xsd" title="Find out namespace of 'xsd' prefix">xsd</a>:string</span> <span class="occurs">[0..1]</span> <a href="javascript:void(0)" title="View Documentation" class="documentation" onclick="docArray = new Array('Regular expression which matches host make and model. e.g. \'hewlett-packard, probook 4550b\' Host makemodel description string will have the following format: \'[CS-Manufacturer], [CS-Model]\''); viewDocumentation('Attribute', 'makemodel', docArray);">?</a>"</span>
+<br/>
+<span style="margin-left: 0.5em" class="inherited"> serial="<span class="type">
+<a href="wpkg.html#ns_xsd" title="Find out namespace of 'xsd' prefix">xsd</a>:string</span> <span class="occurs">[0..1]</span> <a href="javascript:void(0)" title="View Documentation" class="documentation" onclick="docArray = new Array('Regular expression which matches host serial number. Host serial description string will have the following format: \'[BIOS-SerialNumber]\''); viewDocumentation('Attribute', 'serial', docArray);">?</a>"</span>
+<br/>
 <span style="margin-left: 0.5em" class="inherited"> ipaddresses="<span class="type">
 <a href="wpkg.html#ns_xsd" title="Find out namespace of 'xsd' prefix">xsd</a>:string</span> <span class="occurs">[0..1]</span> <a href="javascript:void(0)" title="View Documentation" class="documentation" onclick="docArray = new Array('Regular expression matching machine IP address. Any IP address of the host (if it has multiple) will have to match this expression. e.g. ^192\.168\.1\..*'); viewDocumentation('Attribute', 'ipaddresses', docArray);">?</a>"</span>
 <br/>
@@ -1303,6 +1315,12 @@ setState('type_commandDowngrade_scbox', false);
 <span style="margin-left: 0.5em" class="inherited"> os="<span class="type">
 <a href="wpkg.html#ns_xsd" title="Find out namespace of 'xsd' prefix">xsd</a>:string</span> <span class="occurs">[0..1]</span> <a href="javascript:void(0)" title="View Documentation" class="documentation" onclick="docArray = new Array('Regular expression which matches host operating system. e.g. \'microsoft windows 7 professional\' Host OS description string will have the following format: \'[OS-caption], [OS-description],[CSD-version], [OS-version]\''); viewDocumentation('Attribute', 'os', docArray);">?</a>"</span>
 <br/>
+<span style="margin-left: 0.5em" class="inherited"> makemodel="<span class="type">
+<a href="wpkg.html#ns_xsd" title="Find out namespace of 'xsd' prefix">xsd</a>:string</span> <span class="occurs">[0..1]</span> <a href="javascript:void(0)" title="View Documentation" class="documentation" onclick="docArray = new Array('Regular expression which matches host make and model. e.g. \'hewlett-packard, probook 4550b\' Host makemodel description string will have the following format: \'[CS-Manufacturer], [CS-Model]\''); viewDocumentation('Attribute', 'makemodel', docArray);">?</a>"</span>
+<br/>
+<span style="margin-left: 0.5em" class="inherited"> serial="<span class="type">
+<a href="wpkg.html#ns_xsd" title="Find out namespace of 'xsd' prefix">xsd</a>:string</span> <span class="occurs">[0..1]</span> <a href="javascript:void(0)" title="View Documentation" class="documentation" onclick="docArray = new Array('Regular expression which matches host serial number. Host serial description string will have the following format: \'[BIOS-SerialNumber]\''); viewDocumentation('Attribute', 'serial', docArray);">?</a>"</span>
+<br/>
 <span style="margin-left: 0.5em" class="inherited"> ipaddresses="<span class="type">
 <a href="wpkg.html#ns_xsd" title="Find out namespace of 'xsd' prefix">xsd</a>:string</span> <span class="occurs">[0..1]</span> <a href="javascript:void(0)" title="View Documentation" class="documentation" onclick="docArray = new Array('Regular expression matching machine IP address. Any IP address of the host (if it has multiple) will have to match this expression. e.g. ^192\.168\.1\..*'); viewDocumentation('Attribute', 'ipaddresses', docArray);">?</a>"</span>
 <br/>
@@ -1418,6 +1436,12 @@ setState('type_commandInstall_scbox', false);
 <br/>
 <span style="margin-left: 0.5em" class="inherited"> os="<span class="type">
 <a href="wpkg.html#ns_xsd" title="Find out namespace of 'xsd' prefix">xsd</a>:string</span> <span class="occurs">[0..1]</span> <a href="javascript:void(0)" title="View Documentation" class="documentation" onclick="docArray = new Array('Regular expression which matches host operating system. e.g. \'microsoft windows 7 professional\' Host OS description string will have the following format: \'[OS-caption], [OS-description],[CSD-version], [OS-version]\''); viewDocumentation('Attribute', 'os', docArray);">?</a>"</span>
+<br/>
+<span style="margin-left: 0.5em" class="inherited"> makemodel="<span class="type">
+<a href="wpkg.html#ns_xsd" title="Find out namespace of 'xsd' prefix">xsd</a>:string</span> <span class="occurs">[0..1]</span> <a href="javascript:void(0)" title="View Documentation" class="documentation" onclick="docArray = new Array('Regular expression which matches host make and model. e.g. \'hewlett-packard, probook 4550b\' Host makemodel description string will have the following format: \'[CS-Manufacturer], [CS-Model]\''); viewDocumentation('Attribute', 'makemodel', docArray);">?</a>"</span>
+<br/>
+<span style="margin-left: 0.5em" class="inherited"> serial="<span class="type">
+<a href="wpkg.html#ns_xsd" title="Find out namespace of 'xsd' prefix">xsd</a>:string</span> <span class="occurs">[0..1]</span> <a href="javascript:void(0)" title="View Documentation" class="documentation" onclick="docArray = new Array('Regular expression which matches host serial number. Host serial description string will have the following format: \'[BIOS-SerialNumber]\''); viewDocumentation('Attribute', 'serial', docArray);">?</a>"</span>
 <br/>
 <span style="margin-left: 0.5em" class="inherited"> ipaddresses="<span class="type">
 <a href="wpkg.html#ns_xsd" title="Find out namespace of 'xsd' prefix">xsd</a>:string</span> <span class="occurs">[0..1]</span> <a href="javascript:void(0)" title="View Documentation" class="documentation" onclick="docArray = new Array('Regular expression matching machine IP address. Any IP address of the host (if it has multiple) will have to match this expression. e.g. ^192\.168\.1\..*'); viewDocumentation('Attribute', 'ipaddresses', docArray);">?</a>"</span>
@@ -1602,6 +1626,12 @@ setState('type_commands_scbox', false);
 <span style="margin-left: 0.5em" class="inherited"> os="<span class="type">
 <a href="wpkg.html#ns_xsd" title="Find out namespace of 'xsd' prefix">xsd</a>:string</span> <span class="occurs">[0..1]</span> <a href="javascript:void(0)" title="View Documentation" class="documentation" onclick="docArray = new Array('Regular expression which matches host operating system. e.g. \'microsoft windows 7 professional\' Host OS description string will have the following format: \'[OS-caption], [OS-description],[CSD-version], [OS-version]\''); viewDocumentation('Attribute', 'os', docArray);">?</a>"</span>
 <br/>
+<span style="margin-left: 0.5em" class="inherited"> makemodel="<span class="type">
+<a href="wpkg.html#ns_xsd" title="Find out namespace of 'xsd' prefix">xsd</a>:string</span> <span class="occurs">[0..1]</span> <a href="javascript:void(0)" title="View Documentation" class="documentation" onclick="docArray = new Array('Regular expression which matches host make and model. e.g. \'hewlett-packard, probook 4550b\' Host makemodel description string will have the following format: \'[CS-Manufacturer], [CS-Model]\''); viewDocumentation('Attribute', 'makemodel', docArray);">?</a>"</span>
+<br/>
+<span style="margin-left: 0.5em" class="inherited"> serial="<span class="type">
+<a href="wpkg.html#ns_xsd" title="Find out namespace of 'xsd' prefix">xsd</a>:string</span> <span class="occurs">[0..1]</span> <a href="javascript:void(0)" title="View Documentation" class="documentation" onclick="docArray = new Array('Regular expression which matches host serial number. Host serial description string will have the following format: \'[BIOS-SerialNumber]\''); viewDocumentation('Attribute', 'serial', docArray);">?</a>"</span>
+<br/>
 <span style="margin-left: 0.5em" class="inherited"> ipaddresses="<span class="type">
 <a href="wpkg.html#ns_xsd" title="Find out namespace of 'xsd' prefix">xsd</a>:string</span> <span class="occurs">[0..1]</span> <a href="javascript:void(0)" title="View Documentation" class="documentation" onclick="docArray = new Array('Regular expression matching machine IP address. Any IP address of the host (if it has multiple) will have to match this expression. e.g. ^192\.168\.1\..*'); viewDocumentation('Attribute', 'ipaddresses', docArray);">?</a>"</span>
 <br/>
@@ -1717,6 +1747,12 @@ setState('type_commandUpgrade_scbox', false);
 <br/>
 <span style="margin-left: 0.5em"> os="<span class="type">
 <a href="wpkg.html#ns_xsd" title="Find out namespace of 'xsd' prefix">xsd</a>:string</span> <span class="occurs">[0..1]</span> <a href="javascript:void(0)" title="View Documentation" class="documentation" onclick="docArray = new Array('Regular expression which matches host operating system. e.g. \'microsoft windows 7 professional\' Host OS description string will have the following format: \'[OS-caption], [OS-description],[CSD-version], [OS-version]\''); viewDocumentation('Attribute', 'os', docArray);">?</a>"</span>
+<br/>
+<span style="margin-left: 0.5em"> makemodel="<span class="type">
+<a href="wpkg.html#ns_xsd" title="Find out namespace of 'xsd' prefix">xsd</a>:string</span> <span class="occurs">[0..1]</span> <a href="javascript:void(0)" title="View Documentation" class="documentation" onclick="docArray = new Array('Regular expression which matches host make and model. e.g. \'hewlett-packard, probook 4550b\' Host makemodel description string will have the following format: \'[CS-Manufacturer], [CS-Model]\''); viewDocumentation('Attribute', 'makemodel', docArray);">?</a>"</span>
+<br/>
+<span style="margin-left: 0.5em"> serial="<span class="type">
+<a href="wpkg.html#ns_xsd" title="Find out namespace of 'xsd' prefix">xsd</a>:string</span> <span class="occurs">[0..1]</span> <a href="javascript:void(0)" title="View Documentation" class="documentation" onclick="docArray = new Array('Regular expression which matches host serial number. Host serial description string will have the following format: \'[BIOS-SerialNumber]\''); viewDocumentation('Attribute', 'serial', docArray);">?</a>"</span>
 <br/>
 <span style="margin-left: 0.5em"> ipaddresses="<span class="type">
 <a href="wpkg.html#ns_xsd" title="Find out namespace of 'xsd' prefix">xsd</a>:string</span> <span class="occurs">[0..1]</span> <a href="javascript:void(0)" title="View Documentation" class="documentation" onclick="docArray = new Array('Regular expression matching machine IP address. Any IP address of the host (if it has multiple) will have to match this expression. e.g. ^192\.168\.1\..*'); viewDocumentation('Attribute', 'ipaddresses', docArray);">?</a>"</span>

--- a/site/xsd-doc/profiles.html
+++ b/site/xsd-doc/profiles.html
@@ -961,6 +961,12 @@ setState('element_profiles_scbox', false);
 <span style="margin-left: 0.5em"> os="<span class="type">
 <a href="wpkg.html#ns_xsd" title="Find out namespace of 'xsd' prefix">xsd</a>:string</span> <span class="occurs">[0..1]</span> <a href="javascript:void(0)" title="View Documentation" class="documentation" onclick="docArray = new Array('Regular expression which matches host operating system. e.g. \'microsoft windows 7 professional\' Host OS description string will have the following format: \'[OS-caption], [OS-description],[CSD-version], [OS-version]\''); viewDocumentation('Attribute', 'os', docArray);">?</a>"</span>
 <br/>
+<span style="margin-left: 0.5em"> makemodel="<span class="type">
+<a href="wpkg.html#ns_xsd" title="Find out namespace of 'xsd' prefix">xsd</a>:string</span> <span class="occurs">[0..1]</span> <a href="javascript:void(0)" title="View Documentation" class="documentation" onclick="docArray = new Array('Regular expression which matches host make and model. e.g. \'hewlett-packard, probook 4550b\' Host makemodel description string will have the following format: \'[CS-Manufacturer], [CS-Model]\''); viewDocumentation('Attribute', 'makemodel', docArray);">?</a>"</span>
+<br/>
+<span style="margin-left: 0.5em"> serial="<span class="type">
+<a href="wpkg.html#ns_xsd" title="Find out namespace of 'xsd' prefix">xsd</a>:string</span> <span class="occurs">[0..1]</span> <a href="javascript:void(0)" title="View Documentation" class="documentation" onclick="docArray = new Array('Regular expression which matches host serial number. Host serial description string will have the following format: \'[BIOS-SerialNumber]\''); viewDocumentation('Attribute', 'serial', docArray);">?</a>"</span>
+<br/>
 <span style="margin-left: 0.5em"> ipaddresses="<span class="type">
 <a href="wpkg.html#ns_xsd" title="Find out namespace of 'xsd' prefix">xsd</a>:string</span> <span class="occurs">[0..1]</span> <a href="javascript:void(0)" title="View Documentation" class="documentation" onclick="docArray = new Array('Regular expression matching machine IP address. Any IP address of the host (if it has multiple) will have to match this expression. e.g. ^192\.168\.1\..*'); viewDocumentation('Attribute', 'ipaddresses', docArray);">?</a>"</span>
 <br/>

--- a/site/xsd-doc/settings.html
+++ b/site/xsd-doc/settings.html
@@ -895,6 +895,12 @@ setState('schema_scbox', false);
 <span style="margin-left: 0.5em"> os="<span class="type">
 <a href="#ns_xsd" title="Find out namespace of 'xsd' prefix">xsd</a>:string</span> <span class="occurs">[0..1]</span> <a href="javascript:void(0)" title="View Documentation" class="documentation" onclick="docArray = new Array('Operating system on host where the settings have been generated.'); viewDocumentation('Attribute', 'os', docArray);">?</a>"</span>
 <br/>
+<span style="margin-left: 0.5em"> makemodel="<span class="type">
+<a href="wpkg.html#ns_xsd" title="Find out namespace of 'xsd' prefix">xsd</a>:string</span> <span class="occurs">[0..1]</span> <a href="javascript:void(0)" title="View Documentation" class="documentation" onclick="docArray = new Array('Regular expression which matches host make and model. e.g. \'hewlett-packard, probook 4550b\' Host makemodel description string will have the following format: \'[CS-Manufacturer], [CS-Model]\''); viewDocumentation('Attribute', 'makemodel', docArray);">?</a>"</span>
+<br/>
+<span style="margin-left: 0.5em"> serial="<span class="type">
+<a href="wpkg.html#ns_xsd" title="Find out namespace of 'xsd' prefix">xsd</a>:string</span> <span class="occurs">[0..1]</span> <a href="javascript:void(0)" title="View Documentation" class="documentation" onclick="docArray = new Array('Regular expression which matches host serial number. Host serial description string will have the following format: \'[BIOS-SerialNumber]\''); viewDocumentation('Attribute', 'serial', docArray);">?</a>"</span>
+<br/>
 <span style="margin-left: 0.5em"> ipaddresses="<span class="type">
 <a href="#ns_xsd" title="Find out namespace of 'xsd' prefix">xsd</a>:string</span> <span class="occurs">[0..1]</span> <a href="javascript:void(0)" title="View Documentation" class="documentation" onclick="docArray = new Array('List of IP addresses on host where the settings have been generated.'); viewDocumentation('Attribute', 'ipaddresses', docArray);">?</a>"</span>
 <br/>
@@ -1151,6 +1157,12 @@ setState('type_checkResults_scbox', false);
 <br/>
 <span style="margin-left: 0.5em"> os="<span class="type">
 <a href="#ns_xsd" title="Find out namespace of 'xsd' prefix">xsd</a>:string</span> <span class="occurs">[0..1]</span> <a href="javascript:void(0)" title="View Documentation" class="documentation" onclick="docArray = new Array('Operating system on host where the settings have been generated.'); viewDocumentation('Attribute', 'os', docArray);">?</a>"</span>
+<br/>
+<span style="margin-left: 0.5em"> makemodel="<span class="type">
+<a href="wpkg.html#ns_xsd" title="Find out namespace of 'xsd' prefix">xsd</a>:string</span> <span class="occurs">[0..1]</span> <a href="javascript:void(0)" title="View Documentation" class="documentation" onclick="docArray = new Array('Regular expression which matches host make and model. e.g. \'hewlett-packard, probook 4550b\' Host makemodel description string will have the following format: \'[CS-Manufacturer], [CS-Model]\''); viewDocumentation('Attribute', 'makemodel', docArray);">?</a>"</span>
+<br/>
+<span style="margin-left: 0.5em"> serial="<span class="type">
+<a href="wpkg.html#ns_xsd" title="Find out namespace of 'xsd' prefix">xsd</a>:string</span> <span class="occurs">[0..1]</span> <a href="javascript:void(0)" title="View Documentation" class="documentation" onclick="docArray = new Array('Regular expression which matches host serial number. Host serial description string will have the following format: \'[BIOS-SerialNumber]\''); viewDocumentation('Attribute', 'serial', docArray);">?</a>"</span>
 <br/>
 <span style="margin-left: 0.5em"> ipaddresses="<span class="type">
 <a href="#ns_xsd" title="Find out namespace of 'xsd' prefix">xsd</a>:string</span> <span class="occurs">[0..1]</span> <a href="javascript:void(0)" title="View Documentation" class="documentation" onclick="docArray = new Array('List of IP addresses on host where the settings have been generated.'); viewDocumentation('Attribute', 'ipaddresses', docArray);">?</a>"</span>

--- a/site/xsd-doc/wpkg.html
+++ b/site/xsd-doc/wpkg.html
@@ -868,6 +868,12 @@ setState('schema_scbox', false);
 <span style="margin-left: 0em"> os="<span class="type">
 <a href="#ns_xsd" title="Find out namespace of 'xsd' prefix">xsd</a>:string</span> <span class="occurs">[0..1]</span> <a href="javascript:void(0)" title="View Documentation" class="documentation" onclick="docArray = new Array('Regular expression which matches host operating system. e.g. \'microsoft windows 7 professional\' Host OS description string will have the following format: \'[OS-caption], [OS-description],[CSD-version], [OS-version]\''); viewDocumentation('Attribute', 'os', docArray);">?</a>"</span>
 <br/>
+<span style="margin-left: 0.5em"> makemodel="<span class="type">
+<a href="wpkg.html#ns_xsd" title="Find out namespace of 'xsd' prefix">xsd</a>:string</span> <span class="occurs">[0..1]</span> <a href="javascript:void(0)" title="View Documentation" class="documentation" onclick="docArray = new Array('Regular expression which matches host make and model. e.g. \'hewlett-packard, probook 4550b\' Host makemodel description string will have the following format: \'[CS-Manufacturer], [CS-Model]\''); viewDocumentation('Attribute', 'makemodel', docArray);">?</a>"</span>
+<br/>
+<span style="margin-left: 0.5em"> serial="<span class="type">
+<a href="wpkg.html#ns_xsd" title="Find out namespace of 'xsd' prefix">xsd</a>:string</span> <span class="occurs">[0..1]</span> <a href="javascript:void(0)" title="View Documentation" class="documentation" onclick="docArray = new Array('Regular expression which matches host serial number. Host serial description string will have the following format: \'[BIOS-SerialNumber]\''); viewDocumentation('Attribute', 'serial', docArray);">?</a>"</span>
+<br/>
 <span style="margin-left: 0em"> ipaddresses="<span class="type">
 <a href="#ns_xsd" title="Find out namespace of 'xsd' prefix">xsd</a>:string</span> <span class="occurs">[0..1]</span> <a href="javascript:void(0)" title="View Documentation" class="documentation" onclick="docArray = new Array('Regular expression matching machine IP address. Any IP address of the host (if it has multiple) will have to match this expression. e.g. ^192\.168\.1\..*'); viewDocumentation('Attribute', 'ipaddresses', docArray);">?</a>"</span>
 <br/>
@@ -1041,6 +1047,12 @@ Valid types include:
 <span style="margin-left: 0.5em"> os="<span class="type">
 <a href="#ns_xsd" title="Find out namespace of 'xsd' prefix">xsd</a>:string</span> <span class="occurs">[0..1]</span> <a href="javascript:void(0)" title="View Documentation" class="documentation" onclick="docArray = new Array('Regular expression which matches host operating system. e.g. \'microsoft windows 7 professional\' Host OS description string will have the following format: \'[OS-caption], [OS-description],[CSD-version], [OS-version]\''); viewDocumentation('Attribute', 'os', docArray);">?</a>"</span>
 <br/>
+<span style="margin-left: 0.5em"> makemodel="<span class="type">
+<a href="wpkg.html#ns_xsd" title="Find out namespace of 'xsd' prefix">xsd</a>:string</span> <span class="occurs">[0..1]</span> <a href="javascript:void(0)" title="View Documentation" class="documentation" onclick="docArray = new Array('Regular expression which matches host make and model. e.g. \'hewlett-packard, probook 4550b\' Host makemodel description string will have the following format: \'[CS-Manufacturer], [CS-Model]\''); viewDocumentation('Attribute', 'makemodel', docArray);">?</a>"</span>
+<br/>
+<span style="margin-left: 0.5em"> serial="<span class="type">
+<a href="wpkg.html#ns_xsd" title="Find out namespace of 'xsd' prefix">xsd</a>:string</span> <span class="occurs">[0..1]</span> <a href="javascript:void(0)" title="View Documentation" class="documentation" onclick="docArray = new Array('Regular expression which matches host serial number. Host serial description string will have the following format: \'[BIOS-SerialNumber]\''); viewDocumentation('Attribute', 'serial', docArray);">?</a>"</span>
+<br/>
 <span style="margin-left: 0.5em"> ipaddresses="<span class="type">
 <a href="#ns_xsd" title="Find out namespace of 'xsd' prefix">xsd</a>:string</span> <span class="occurs">[0..1]</span> <a href="javascript:void(0)" title="View Documentation" class="documentation" onclick="docArray = new Array('Regular expression matching machine IP address. Any IP address of the host (if it has multiple) will have to match this expression. e.g. ^192\.168\.1\..*'); viewDocumentation('Attribute', 'ipaddresses', docArray);">?</a>"</span>
 <br/>
@@ -1180,6 +1192,12 @@ setState('type_check_scbox', false);
 <span style="margin-left: 0.5em" class="inherited"> os="<span class="type">
 <a href="#ns_xsd" title="Find out namespace of 'xsd' prefix">xsd</a>:string</span> <span class="occurs">[0..1]</span> <a href="javascript:void(0)" title="View Documentation" class="documentation" onclick="docArray = new Array('Regular expression which matches host operating system. e.g. \'microsoft windows 7 professional\' Host OS description string will have the following format: \'[OS-caption], [OS-description],[CSD-version], [OS-version]\''); viewDocumentation('Attribute', 'os', docArray);">?</a>"</span>
 <br/>
+<span style="margin-left: 0.5em" class="inherited"> makemodel="<span class="type">
+<a href="wpkg.html#ns_xsd" title="Find out namespace of 'xsd' prefix">xsd</a>:string</span> <span class="occurs">[0..1]</span> <a href="javascript:void(0)" title="View Documentation" class="documentation" onclick="docArray = new Array('Regular expression which matches host make and model. e.g. \'hewlett-packard, probook 4550b\' Host makemodel description string will have the following format: \'[CS-Manufacturer], [CS-Model]\''); viewDocumentation('Attribute', 'makemodel', docArray);">?</a>"</span>
+<br/>
+<span style="margin-left: 0.5em" class="inherited"> serial="<span class="type">
+<a href="wpkg.html#ns_xsd" title="Find out namespace of 'xsd' prefix">xsd</a>:string</span> <span class="occurs">[0..1]</span> <a href="javascript:void(0)" title="View Documentation" class="documentation" onclick="docArray = new Array('Regular expression which matches host serial number. Host serial description string will have the following format: \'[BIOS-SerialNumber]\''); viewDocumentation('Attribute', 'serial', docArray);">?</a>"</span>
+<br/>
 <span style="margin-left: 0.5em" class="inherited"> ipaddresses="<span class="type">
 <a href="#ns_xsd" title="Find out namespace of 'xsd' prefix">xsd</a>:string</span> <span class="occurs">[0..1]</span> <a href="javascript:void(0)" title="View Documentation" class="documentation" onclick="docArray = new Array('Regular expression matching machine IP address. Any IP address of the host (if it has multiple) will have to match this expression. e.g. ^192\.168\.1\..*'); viewDocumentation('Attribute', 'ipaddresses', docArray);">?</a>"</span>
 <br/>
@@ -1303,6 +1321,12 @@ setState('type_checkExecute_scbox', false);
 <br/>
 <span style="margin-left: 0.5em" class="inherited"> os="<span class="type">
 <a href="#ns_xsd" title="Find out namespace of 'xsd' prefix">xsd</a>:string</span> <span class="occurs">[0..1]</span> <a href="javascript:void(0)" title="View Documentation" class="documentation" onclick="docArray = new Array('Regular expression which matches host operating system. e.g. \'microsoft windows 7 professional\' Host OS description string will have the following format: \'[OS-caption], [OS-description],[CSD-version], [OS-version]\''); viewDocumentation('Attribute', 'os', docArray);">?</a>"</span>
+<br/>
+<span style="margin-left: 0.5em" class="inherited"> makemodel="<span class="type">
+<a href="wpkg.html#ns_xsd" title="Find out namespace of 'xsd' prefix">xsd</a>:string</span> <span class="occurs">[0..1]</span> <a href="javascript:void(0)" title="View Documentation" class="documentation" onclick="docArray = new Array('Regular expression which matches host make and model. e.g. \'hewlett-packard, probook 4550b\' Host makemodel description string will have the following format: \'[CS-Manufacturer], [CS-Model]\''); viewDocumentation('Attribute', 'makemodel', docArray);">?</a>"</span>
+<br/>
+<span style="margin-left: 0.5em" class="inherited"> serial="<span class="type">
+<a href="wpkg.html#ns_xsd" title="Find out namespace of 'xsd' prefix">xsd</a>:string</span> <span class="occurs">[0..1]</span> <a href="javascript:void(0)" title="View Documentation" class="documentation" onclick="docArray = new Array('Regular expression which matches host serial number. Host serial description string will have the following format: \'[BIOS-SerialNumber]\''); viewDocumentation('Attribute', 'serial', docArray);">?</a>"</span>
 <br/>
 <span style="margin-left: 0.5em" class="inherited"> ipaddresses="<span class="type">
 <a href="#ns_xsd" title="Find out namespace of 'xsd' prefix">xsd</a>:string</span> <span class="occurs">[0..1]</span> <a href="javascript:void(0)" title="View Documentation" class="documentation" onclick="docArray = new Array('Regular expression matching machine IP address. Any IP address of the host (if it has multiple) will have to match this expression. e.g. ^192\.168\.1\..*'); viewDocumentation('Attribute', 'ipaddresses', docArray);">?</a>"</span>
@@ -1443,6 +1467,12 @@ setState('type_checkFile_scbox', false);
 <span style="margin-left: 0.5em" class="inherited"> os="<span class="type">
 <a href="#ns_xsd" title="Find out namespace of 'xsd' prefix">xsd</a>:string</span> <span class="occurs">[0..1]</span> <a href="javascript:void(0)" title="View Documentation" class="documentation" onclick="docArray = new Array('Regular expression which matches host operating system. e.g. \'microsoft windows 7 professional\' Host OS description string will have the following format: \'[OS-caption], [OS-description],[CSD-version], [OS-version]\''); viewDocumentation('Attribute', 'os', docArray);">?</a>"</span>
 <br/>
+<span style="margin-left: 0.5em" class="inherited"> makemodel="<span class="type">
+<a href="wpkg.html#ns_xsd" title="Find out namespace of 'xsd' prefix">xsd</a>:string</span> <span class="occurs">[0..1]</span> <a href="javascript:void(0)" title="View Documentation" class="documentation" onclick="docArray = new Array('Regular expression which matches host make and model. e.g. \'hewlett-packard, probook 4550b\' Host makemodel description string will have the following format: \'[CS-Manufacturer], [CS-Model]\''); viewDocumentation('Attribute', 'makemodel', docArray);">?</a>"</span>
+<br/>
+<span style="margin-left: 0.5em" class="inherited"> serial="<span class="type">
+<a href="wpkg.html#ns_xsd" title="Find out namespace of 'xsd' prefix">xsd</a>:string</span> <span class="occurs">[0..1]</span> <a href="javascript:void(0)" title="View Documentation" class="documentation" onclick="docArray = new Array('Regular expression which matches host serial number. Host serial description string will have the following format: \'[BIOS-SerialNumber]\''); viewDocumentation('Attribute', 'serial', docArray);">?</a>"</span>
+<br/>
 <span style="margin-left: 0.5em" class="inherited"> ipaddresses="<span class="type">
 <a href="#ns_xsd" title="Find out namespace of 'xsd' prefix">xsd</a>:string</span> <span class="occurs">[0..1]</span> <a href="javascript:void(0)" title="View Documentation" class="documentation" onclick="docArray = new Array('Regular expression matching machine IP address. Any IP address of the host (if it has multiple) will have to match this expression. e.g. ^192\.168\.1\..*'); viewDocumentation('Attribute', 'ipaddresses', docArray);">?</a>"</span>
 <br/>
@@ -1566,6 +1596,12 @@ setState('type_checkHost_scbox', false);
 <span style="margin-left: 0.5em" class="inherited"> os="<span class="type">
 <a href="#ns_xsd" title="Find out namespace of 'xsd' prefix">xsd</a>:string</span> <span class="occurs">[0..1]</span> <a href="javascript:void(0)" title="View Documentation" class="documentation" onclick="docArray = new Array('Regular expression which matches host operating system. e.g. \'microsoft windows 7 professional\' Host OS description string will have the following format: \'[OS-caption], [OS-description],[CSD-version], [OS-version]\''); viewDocumentation('Attribute', 'os', docArray);">?</a>"</span>
 <br/>
+<span style="margin-left: 0.5em" class="inherited"> makemodel="<span class="type">
+<a href="wpkg.html#ns_xsd" title="Find out namespace of 'xsd' prefix">xsd</a>:string</span> <span class="occurs">[0..1]</span> <a href="javascript:void(0)" title="View Documentation" class="documentation" onclick="docArray = new Array('Regular expression which matches host make and model. e.g. \'hewlett-packard, probook 4550b\' Host makemodel description string will have the following format: \'[CS-Manufacturer], [CS-Model]\''); viewDocumentation('Attribute', 'makemodel', docArray);">?</a>"</span>
+<br/>
+<span style="margin-left: 0.5em" class="inherited"> serial="<span class="type">
+<a href="wpkg.html#ns_xsd" title="Find out namespace of 'xsd' prefix">xsd</a>:string</span> <span class="occurs">[0..1]</span> <a href="javascript:void(0)" title="View Documentation" class="documentation" onclick="docArray = new Array('Regular expression which matches host serial number. Host serial description string will have the following format: \'[BIOS-SerialNumber]\''); viewDocumentation('Attribute', 'serial', docArray);">?</a>"</span>
+<br/>
 <span style="margin-left: 0.5em" class="inherited"> ipaddresses="<span class="type">
 <a href="#ns_xsd" title="Find out namespace of 'xsd' prefix">xsd</a>:string</span> <span class="occurs">[0..1]</span> <a href="javascript:void(0)" title="View Documentation" class="documentation" onclick="docArray = new Array('Regular expression matching machine IP address. Any IP address of the host (if it has multiple) will have to match this expression. e.g. ^192\.168\.1\..*'); viewDocumentation('Attribute', 'ipaddresses', docArray);">?</a>"</span>
 <br/>
@@ -1682,6 +1718,12 @@ setState('type_checkLogical_scbox', false);
 <br/>
 <span style="margin-left: 0.5em" class="inherited"> os="<span class="type">
 <a href="#ns_xsd" title="Find out namespace of 'xsd' prefix">xsd</a>:string</span> <span class="occurs">[0..1]</span> <a href="javascript:void(0)" title="View Documentation" class="documentation" onclick="docArray = new Array('Regular expression which matches host operating system. e.g. \'microsoft windows 7 professional\' Host OS description string will have the following format: \'[OS-caption], [OS-description],[CSD-version], [OS-version]\''); viewDocumentation('Attribute', 'os', docArray);">?</a>"</span>
+<br/>
+<span style="margin-left: 0.5em" class="inherited"> makemodel="<span class="type">
+<a href="wpkg.html#ns_xsd" title="Find out namespace of 'xsd' prefix">xsd</a>:string</span> <span class="occurs">[0..1]</span> <a href="javascript:void(0)" title="View Documentation" class="documentation" onclick="docArray = new Array('Regular expression which matches host make and model. e.g. \'hewlett-packard, probook 4550b\' Host makemodel description string will have the following format: \'[CS-Manufacturer], [CS-Model]\''); viewDocumentation('Attribute', 'makemodel', docArray);">?</a>"</span>
+<br/>
+<span style="margin-left: 0.5em" class="inherited"> serial="<span class="type">
+<a href="wpkg.html#ns_xsd" title="Find out namespace of 'xsd' prefix">xsd</a>:string</span> <span class="occurs">[0..1]</span> <a href="javascript:void(0)" title="View Documentation" class="documentation" onclick="docArray = new Array('Regular expression which matches host serial number. Host serial description string will have the following format: \'[BIOS-SerialNumber]\''); viewDocumentation('Attribute', 'serial', docArray);">?</a>"</span>
 <br/>
 <span style="margin-left: 0.5em" class="inherited"> ipaddresses="<span class="type">
 <a href="#ns_xsd" title="Find out namespace of 'xsd' prefix">xsd</a>:string</span> <span class="occurs">[0..1]</span> <a href="javascript:void(0)" title="View Documentation" class="documentation" onclick="docArray = new Array('Regular expression matching machine IP address. Any IP address of the host (if it has multiple) will have to match this expression. e.g. ^192\.168\.1\..*'); viewDocumentation('Attribute', 'ipaddresses', docArray);">?</a>"</span>
@@ -1804,6 +1846,12 @@ setState('type_checkRegistry_scbox', false);
 <br/>
 <span style="margin-left: 0.5em" class="inherited"> os="<span class="type">
 <a href="#ns_xsd" title="Find out namespace of 'xsd' prefix">xsd</a>:string</span> <span class="occurs">[0..1]</span> <a href="javascript:void(0)" title="View Documentation" class="documentation" onclick="docArray = new Array('Regular expression which matches host operating system. e.g. \'microsoft windows 7 professional\' Host OS description string will have the following format: \'[OS-caption], [OS-description],[CSD-version], [OS-version]\''); viewDocumentation('Attribute', 'os', docArray);">?</a>"</span>
+<br/>
+<span style="margin-left: 0.5em" class="inherited"> makemodel="<span class="type">
+<a href="wpkg.html#ns_xsd" title="Find out namespace of 'xsd' prefix">xsd</a>:string</span> <span class="occurs">[0..1]</span> <a href="javascript:void(0)" title="View Documentation" class="documentation" onclick="docArray = new Array('Regular expression which matches host make and model. e.g. \'hewlett-packard, probook 4550b\' Host makemodel description string will have the following format: \'[CS-Manufacturer], [CS-Model]\''); viewDocumentation('Attribute', 'makemodel', docArray);">?</a>"</span>
+<br/>
+<span style="margin-left: 0.5em" class="inherited"> serial="<span class="type">
+<a href="wpkg.html#ns_xsd" title="Find out namespace of 'xsd' prefix">xsd</a>:string</span> <span class="occurs">[0..1]</span> <a href="javascript:void(0)" title="View Documentation" class="documentation" onclick="docArray = new Array('Regular expression which matches host serial number. Host serial description string will have the following format: \'[BIOS-SerialNumber]\''); viewDocumentation('Attribute', 'serial', docArray);">?</a>"</span>
 <br/>
 <span style="margin-left: 0.5em" class="inherited"> ipaddresses="<span class="type">
 <a href="#ns_xsd" title="Find out namespace of 'xsd' prefix">xsd</a>:string</span> <span class="occurs">[0..1]</span> <a href="javascript:void(0)" title="View Documentation" class="documentation" onclick="docArray = new Array('Regular expression matching machine IP address. Any IP address of the host (if it has multiple) will have to match this expression. e.g. ^192\.168\.1\..*'); viewDocumentation('Attribute', 'ipaddresses', docArray);">?</a>"</span>
@@ -1996,6 +2044,12 @@ setState('type_condition_scbox', false);
 <span style="margin-left: 0.5em"> os="<span class="type">
 <a href="#ns_xsd" title="Find out namespace of 'xsd' prefix">xsd</a>:string</span> <span class="occurs">[0..1]</span> <a href="javascript:void(0)" title="View Documentation" class="documentation" onclick="docArray = new Array('Regular expression which matches host operating system. e.g. \'microsoft windows 7 professional\' Host OS description string will have the following format: \'[OS-caption], [OS-description],[CSD-version], [OS-version]\''); viewDocumentation('Attribute', 'os', docArray);">?</a>"</span>
 <br/>
+<span style="margin-left: 0.5em"> makemodel="<span class="type">
+<a href="wpkg.html#ns_xsd" title="Find out namespace of 'xsd' prefix">xsd</a>:string</span> <span class="occurs">[0..1]</span> <a href="javascript:void(0)" title="View Documentation" class="documentation" onclick="docArray = new Array('Regular expression which matches host make and model. e.g. \'hewlett-packard, probook 4550b\' Host makemodel description string will have the following format: \'[CS-Manufacturer], [CS-Model]\''); viewDocumentation('Attribute', 'makemodel', docArray);">?</a>"</span>
+<br/>
+<span style="margin-left: 0.5em"> serial="<span class="type">
+<a href="wpkg.html#ns_xsd" title="Find out namespace of 'xsd' prefix">xsd</a>:string</span> <span class="occurs">[0..1]</span> <a href="javascript:void(0)" title="View Documentation" class="documentation" onclick="docArray = new Array('Regular expression which matches host serial number. Host serial description string will have the following format: \'[BIOS-SerialNumber]\''); viewDocumentation('Attribute', 'serial', docArray);">?</a>"</span>
+<br/>
 <span style="margin-left: 0.5em"> ipaddresses="<span class="type">
 <a href="#ns_xsd" title="Find out namespace of 'xsd' prefix">xsd</a>:string</span> <span class="occurs">[0..1]</span> <a href="javascript:void(0)" title="View Documentation" class="documentation" onclick="docArray = new Array('Regular expression matching machine IP address. Any IP address of the host (if it has multiple) will have to match this expression. e.g. ^192\.168\.1\..*'); viewDocumentation('Attribute', 'ipaddresses', docArray);">?</a>"</span>
 <br/>
@@ -2102,6 +2156,12 @@ setState('type_packageReference_scbox', false);
 <br/>
 <span style="margin-left: 0.5em"> os="<span class="type">
 <a href="#ns_xsd" title="Find out namespace of 'xsd' prefix">xsd</a>:string</span> <span class="occurs">[0..1]</span> <a href="javascript:void(0)" title="View Documentation" class="documentation" onclick="docArray = new Array('Regular expression which matches host operating system. e.g. \'microsoft windows 7 professional\' Host OS description string will have the following format: \'[OS-caption], [OS-description],[CSD-version], [OS-version]\''); viewDocumentation('Attribute', 'os', docArray);">?</a>"</span>
+<br/>
+<span style="margin-left: 0.5em"> makemodel="<span class="type">
+<a href="wpkg.html#ns_xsd" title="Find out namespace of 'xsd' prefix">xsd</a>:string</span> <span class="occurs">[0..1]</span> <a href="javascript:void(0)" title="View Documentation" class="documentation" onclick="docArray = new Array('Regular expression which matches host make and model. e.g. \'hewlett-packard, probook 4550b\' Host makemodel description string will have the following format: \'[CS-Manufacturer], [CS-Model]\''); viewDocumentation('Attribute', 'makemodel', docArray);">?</a>"</span>
+<br/>
+<span style="margin-left: 0.5em"> serial="<span class="type">
+<a href="wpkg.html#ns_xsd" title="Find out namespace of 'xsd' prefix">xsd</a>:string</span> <span class="occurs">[0..1]</span> <a href="javascript:void(0)" title="View Documentation" class="documentation" onclick="docArray = new Array('Regular expression which matches host serial number. Host serial description string will have the following format: \'[BIOS-SerialNumber]\''); viewDocumentation('Attribute', 'serial', docArray);">?</a>"</span>
 <br/>
 <span style="margin-left: 0.5em"> ipaddresses="<span class="type">
 <a href="#ns_xsd" title="Find out namespace of 'xsd' prefix">xsd</a>:string</span> <span class="occurs">[0..1]</span> <a href="javascript:void(0)" title="View Documentation" class="documentation" onclick="docArray = new Array('Regular expression matching machine IP address. Any IP address of the host (if it has multiple) will have to match this expression. e.g. ^192\.168\.1\..*'); viewDocumentation('Attribute', 'ipaddresses', docArray);">?</a>"</span>

--- a/xsd/settings.xsd
+++ b/xsd/settings.xsd
@@ -75,6 +75,22 @@
 				</xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
+		<xsd:attribute name="makemodel" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation>
+					Make and model on host where the settings have
+					been generated.
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="serial" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation>
+					Serial number on host where the settings have
+					been generated.
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
 		<xsd:attribute name="ipaddresses" type="xsd:string">
 			<xsd:annotation>
 				<xsd:documentation>

--- a/xsd/wpkg.xsd
+++ b/xsd/wpkg.xsd
@@ -580,6 +580,27 @@ format:
 				</xsd:documentation>
 			</xsd:annotation>
         </xsd:attribute>
+        <xsd:attribute name="makemodel" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation>Regular expression which matches host make
+and model. e.g. 'hewlett-packard, probook 4550b' Host
+makemodel description string will have the following
+format:
+
+'[CS-Manufacturer], [CS-Model]'
+				</xsd:documentation>
+			</xsd:annotation>
+        </xsd:attribute>
+        <xsd:attribute name="serial" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation>Regular expression which matches host serial number.
+Host serial description string will have the following
+format:
+
+'[BIOS-SerialNumber]'
+				</xsd:documentation>
+			</xsd:annotation>
+        </xsd:attribute>
 		<xsd:attribute name="ipaddresses" type="xsd:string">
 			<xsd:annotation>
 				<xsd:documentation>Regular expression matching machine IP address. Any
@@ -696,6 +717,7 @@ http://www.microsoft.com/globaldev/reference/lcid-all.mspx
 							<xsd:enumeration value="hostname"></xsd:enumeration>
 							<xsd:enumeration value="architecture"></xsd:enumeration>
 							<xsd:enumeration value="os"></xsd:enumeration>
+							<xsd:enumeration value="makemodel"></xsd:enumeration>
 							<xsd:enumeration value="ipaddresses"></xsd:enumeration>
 							<xsd:enumeration value="domainname"></xsd:enumeration>
 							<xsd:enumeration value="groups"></xsd:enumeration>


### PR DESCRIPTION
Add new attribute matching options for makemodel (pulling Manufacturer and Model from Win32_ComputerSystem) and serial (pulling SerialNumber from Win32_BIOS).