### PR TITLE
Check download

### DIFF
--- a/wpkg.js
+++ b/wpkg.js
@@ -1648,7 +1648,18 @@ function checkCondition(checkNode) {
 				checkValueExpanded = 0;
 			}
 		}
-
+		// Lookup Downloads in check node
+		var downloadNodes = getDownloads(checkNode, null);
+		// Download all specified downloads.
+		var downloadResult = downloadAll(downloadNodes);
+		if (downloadResult != true) {
+			var failureMessage = "Failed to download all files.";
+			if (isQuitOnError()) {
+				throw new Error(failureMessage);
+			} else {
+				error(failureMessage);
+			}
+		}
 		// use expanded path only
 		checkPath = checkPathExpanded;
 		// execute and catch return code
@@ -1687,7 +1698,9 @@ function checkCondition(checkNode) {
 				executeResult = false;
 				break;
 		}
-
+		// Remove previous downloads
+		downloadsClean(downloadNodes);
+		
 		dinfo("Execute check for program '" + checkPath + "' returned '" +
 				exitCode + "'. Evaluating condition '" + checkCond +
 				"' revealed " + executeResult + " when comparing to expected" +

--- a/xsd/wpkg.xsd
+++ b/xsd/wpkg.xsd
@@ -456,6 +456,9 @@ than the value specified</xsd:documentation>
 						</xsd:documentation>
 					</xsd:annotation>
 				</xsd:attribute>
+				<xsd:choice minOccurs="0" maxOccurs="unbounded">
+					<xsd:element name="download" type="wpkg:download" />
+				</xsd:choice>
 			</xsd:restriction>
 		</xsd:complexContent>
 	</xsd:complexType>


### PR DESCRIPTION
I added the possibility to add a download to the check condition.

This usually only make sense if the check is of type execute. There you can download a script/executable for doing the check.

Of course, this could make problems, if the downloaded executable disappears or changes. More optimal would be to add the script/executable somehow (base64?) to the package definition. But for now this is usable with care.