### PR TITLE
Check exec timeout

### DIFF
--- a/wpkg.js
+++ b/wpkg.js
@@ -1648,7 +1648,18 @@ function checkCondition(checkNode) {
 				checkValueExpanded = 0;
 			}
 		}
-
+		// Lookup Downloads in check node
+		var downloadNodes = getDownloads(checkNode, null);
+		// Download all specified downloads.
+		var downloadResult = downloadAll(downloadNodes);
+		if (downloadResult != true) {
+			var failureMessage = "Failed to download all files.";
+			if (isQuitOnError()) {
+				throw new Error(failureMessage);
+			} else {
+				error(failureMessage);
+			}
+		}
 		// use expanded path only
 		checkPath = checkPathExpanded;
 		// execute and catch return code
@@ -1687,7 +1698,9 @@ function checkCondition(checkNode) {
 				executeResult = false;
 				break;
 		}
-
+		// Remove previous downloads
+		downloadsClean(downloadNodes);
+		
 		dinfo("Execute check for program '" + checkPath + "' returned '" +
 				exitCode + "'. Evaluating condition '" + checkCond +
 				"' revealed " + executeResult + " when comparing to expected" +

--- a/wpkg.js
+++ b/wpkg.js
@@ -390,6 +390,9 @@ var downloadDir = "%TEMP%";
 /** timeout for downloads */
 var downloadTimeout = 7200;
 
+/** timeout for check execute */
+var checkExecuteTimeout = 600;
+
 /** if set to true logfiles will be appended, otherwise they are overwritten */
 var logAppend = false;
 
@@ -1069,6 +1072,7 @@ function checkCondition(checkNode) {
 	var checkCond = checkNode.getAttribute("condition");
 	var checkPath = checkNode.getAttribute("path");
 	var checkValue = checkNode.getAttribute("value");
+	var checkTimeout = checkNode.getAttribute("timeout");
 
 	// In remote mode try to verify the check using cached check results in
 	// settings database.
@@ -1648,6 +1652,12 @@ function checkCondition(checkNode) {
 				checkValueExpanded = 0;
 			}
 		}
+		// set timeout for execution
+		if (checkTimeout == null) {
+			checkTimeout = checkExecuteTimeout;
+		} else {
+			checkTimeout = parseInt(checkTimeout);
+		}
 		// Lookup Downloads in check node
 		var downloadNodes = getDownloads(checkNode, null);
 		// Download all specified downloads.
@@ -1663,7 +1673,7 @@ function checkCondition(checkNode) {
 		// use expanded path only
 		checkPath = checkPathExpanded;
 		// execute and catch return code
-		var exitCode = exec(checkPath, 3600, null);
+		var exitCode = exec(checkPath, checkTimeout, null);
 
 		var executeResult = false;
 		switch (checkCond) {

--- a/xsd/wpkg.xsd
+++ b/xsd/wpkg.xsd
@@ -456,6 +456,9 @@ than the value specified</xsd:documentation>
 						</xsd:documentation>
 					</xsd:annotation>
 				</xsd:attribute>
+				<xsd:choice minOccurs="0" maxOccurs="unbounded">
+					<xsd:element name="download" type="wpkg:download" />
+				</xsd:choice>
 			</xsd:restriction>
 		</xsd:complexContent>
 	</xsd:complexType>

--- a/xsd/wpkg.xsd
+++ b/xsd/wpkg.xsd
@@ -456,6 +456,13 @@ than the value specified</xsd:documentation>
 						</xsd:documentation>
 					</xsd:annotation>
 				</xsd:attribute>
+				<xsd:attribute name="timeout" type="xsd:integer" use="optional">
+					<xsd:annotation>
+						<xsd:documentation>
+							Value used as timeout for execution.
+						</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
 				<xsd:choice minOccurs="0" maxOccurs="unbounded">
 					<xsd:element name="download" type="wpkg:download" />
 				</xsd:choice>


### PR DESCRIPTION
I have added the timeout attribute to the check with type execute.

The default is hard set to 3600, which can now be changed with the attribute.

It's strange, but in rare cases the script/executable is stuck and blocks. Waiting 1 hour is to long, if you know, that the execute should only run a few seconds. 

Another solution would be to create the script/executable with a timeout, killing itself. But as the timeout was already in `wpkg.js` it was easy to add an attribute to make it configurable. 